### PR TITLE
Add support to customize ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ An Ansible role for installing the Apache web server.
 
 - `apache_version` - Apache version
 - `apache_delete_default_site` - Whether or not to delete the default Apache site (default: `False`)
+- `apache_port` - Default port for Apache to listen on (default: `80`)
+- `apache_ssl_port` - Default port for Apache to listen for SSL on (default: `443`)
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 apache_version: "2.4.7-1ubuntu4.1"
 apache_delete_default_site: False
+apache_port: 80
+apache_ssl_port: 443

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,11 @@
 - name: Install Apache
   apt: pkg=apache2={{ apache_version }} state=present
 
+- name: Configure Apache
+  template: src=ports.conf.j2 dest=/etc/apache2/ports.conf
+  notify:
+    - Restart Apache
+
 - name: Delete default site
   command: a2dissite 000-default
   register: a2dissite

--- a/templates/ports.conf.j2
+++ b/templates/ports.conf.j2
@@ -1,0 +1,15 @@
+# If you just change the port or add more ports here, you will likely also
+# have to change the VirtualHost statement in
+# /etc/apache2/sites-enabled/000-default.conf
+
+Listen {{ apache_port }}
+
+<IfModule ssl_module>
+	Listen {{ apache_ssl_port }}
+</IfModule>
+
+<IfModule mod_gnutls.c>
+	Listen {{ apache_ssl_port }}
+</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
Sometimes it is necessary to alter the ports Apache listens for connections on. Defaults (`80` and `443` for SSL) are preserved, but if you do need to override, `apache_port` and `apache_ssl_port` have been added.
