### PR TITLE
Optionally remove default site stub HTML files

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,3 +17,7 @@
   when: apache_delete_default_site | bool
   notify:
     - Restart Apache
+
+- name: Delete default web root
+  file: path=/var/www/html state=absent
+  when: apache_delete_default_site | bool and a2dissite | changed


### PR DESCRIPTION
Installing the Apache2 package creates a stub site in `/var/www/html`. If `delete_default_site` is truthy, and the default site configuration was just removed, remove the web root stub as well.
