### PR TITLE
Add support for Ansible 2.0

### DIFF
--- a/examples/site.yml
+++ b/examples/site.yml
@@ -1,4 +1,9 @@
 ---
 - hosts: all
+
+  pre_tasks:
+    - name: Update APT cache
+      apt: update_cache=yes
+
   roles:
     - { role: "azavea.apache2" }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install Apache
-  apt: pkg=apache2={{ apache_version }} state=present
+  apt: pkg="apache2={{ apache_version }}" state=present
 
 - name: Configure Apache
   template: src=ports.conf.j2 dest=/etc/apache2/ports.conf


### PR DESCRIPTION
In this case, simply quoting the `pkg` option with the `apache_version` variable.

I also tested to confirm that this change is backwards compatible with Ansible 1.9.x.