### PR TITLE
Fix loose version constraint

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-apache_version: "2.4.*"
+apache_version: "2.4.7-*"
 apache_delete_default_site: False
 apache_port: 80
 apache_ssl_port: 443


### PR DESCRIPTION
The previous version constraint was too loose, and caused a conflict with backported package dependencies. This fix ensures that everything uses the 2.4.7 version.

---

**Testing**

Ensure that the Vagrant project in the `examples` directory provisions correctly.
